### PR TITLE
Add startup script for location server

### DIFF
--- a/src/git-config/add-gpg-to-one.sh
+++ b/src/git-config/add-gpg-to-one.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-#usage: KEY=<your_signing_key> $SCRIPTS/src/git-config/add-gpg-to-one.sh
+# usage: ${WHAT_SCRIPTS}/src/git-config/add-gpg-to-one.sh
+#   requires $WHAT_KEY in $PATH, where
+#   $WHAT_KEY is the 8-digit hex code id of your PGP private key
+
+echo "Adding signing key $WHAT_KEY"
 
 git config commit.gpgsign true &&
-    git config user.signingkey ${KEY}
+    git config user.signingkey ${WHAT_KEY}

--- a/src/remotes/clone-repo.sh
+++ b/src/remotes/clone-repo.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# usage REPO=<name-of-repo> ${WHAT_SCRIPTS}/src/remotes/clone-repo.sh
+
+echo "cloning $REPO"
+
+git clone git@github.com:whereat/${REPO}.git

--- a/src/setup/setup-location-server.sh
+++ b/src/setup/setup-location-server.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# usage: ${WHAT_SCRIPTS}/src/build/build-location-server.sh
+
+cd "$WHAT_ROOT"
+REPO=whereat-location-server
+
+if [ ! -d "$REPO" ]; then
+    echo ${WHAT_SCRIPTS}
+    REPO="$REPO" ${WHAT_SCRIPTS}/src/remotes/clone-repo.sh
+fi
+
+cd ${REPO}
+REPO="$REPO" ${WHAT_SCRIPTS}/src/git-config/add-gpg-to-one.sh
+cd ../
+
+sudo docker run -it --name ${REPO} -p 15000:5000 -v ${WHAT_ROOT}/${REPO}:/${REPO} whereat/${REPO}:0.1 bash


### PR DESCRIPTION
- if repo doesn't exist clone it
- add gpg signing key to repo
- build docker container and run it
  - forward port 15000 on host to 5000 in container
  - mount `${WHAT_ROOT}/whereat-location-server` on host
    to `/whereat-location-server in container`
- required in $PATH:
  - `WHAT_ROOT` (project root for all where@ repos)
  - `WHAT_KEY` (gpg signing key for developer, retrievable via `gpg -K`)
  - `WHAT_SCRIPTS` (path to `whereat-bash` repo)
