### PR TITLE
AG | Debug connect-to-location-server variables

### DIFF
--- a/src/docker/connect-to-location-server.sh
+++ b/src/docker/connect-to-location-server.sh
@@ -4,17 +4,17 @@ set -x
 # usage: ${WHEREAT_SCRIPTS}/src/build/build-location-server.sh [PORT]
 
 cd "$WHEREAT_ROOT"
-repo=whereat-location-server
-port=5000
+REPO=whereat-location-server
+PORT=5000
 
 if [ $# -eq 1 ]; then
-    port=$1
+    PORT=$1
 fi
 
-if [ ! -d "$repo" ]; then
-    repo="$repo" ${WHEREAT_SCRIPTS}/src/remotes/clone-repo.sh
-    cd ${repo}
-    repo="$repo" ${WHEREAT_SCRIPTS}/src/git-config/add-gpg-to-one.sh
+if [ ! -d "$REPO" ]; then
+    REPO="$REPO" ${WHEREAT_SCRIPTS}/src/remotes/clone-REPO.sh
+    cd ${REPO}
+    REPO="$REPO" ${WHEREAT_SCRIPTS}/src/git-config/add-gpg-to-one.sh
     cd $WHEREAT_ROOT
 fi
 
@@ -23,5 +23,5 @@ docker ps -a | grep --quiet whereat-location-server
 if [ $? -eq 0 ]; then
     docker start -i whereat-location-server
 else
-    docker run -it --name ${repo} -p $port:5000 -v ${WHEREAT_ROOT}/${repo}:/${repo} whereat/${repo}:0.1 bash
+    docker run -it --name ${REPO} -p $PORT:5000 -v ${WHEREAT_ROOT}/${REPO}:/${REPO} whereat/${REPO}:0.1 bash
 fi


### PR DESCRIPTION
- bug: no value passed to `clone-repo`, `add-gpg-to-one`
- cause: `repo`/`REPO` inconsistently named in `connect-to-location-server.sh`
- fix: make variable names consistent
- side-effects: adopt consistent all-caps variable names in entire script
  (eg: `PORT` instead of `port`)
